### PR TITLE
Updates watcher version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ author: Ajin Asokan <ajin.panthayil@gmail.com>
 homepage: https://github.com/ajinasokan/recharge
 
 dependencies:
-  watcher: ^0.9.7+13
+  watcher: ^1.0.0
   vm_service: ^2.1.4
 
 environment:


### PR DESCRIPTION
`build_runner` depends on version 1.0.0 from the watcher package. So this should fix the compatibility problems with it being used with build_runner.

I've tested this locally and it worked normally.